### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 [![MseeP Badge](https://mseep.net/pr/qhdrl12-mcp-server-gemini-image-generator-badge.jpg)](https://mseep.ai/app/qhdrl12-mcp-server-gemini-image-generator)
 [![smithery badge](https://smithery.ai/badge/@qhdrl12/mcp-server-gemini-image-gen)](https://smithery.ai/server/@qhdrl12/mcp-server-gemini-image-gen)
 
+<a href="https://glama.ai/mcp/servers/@qhdrl12/mcp-server-gemini-image-generator">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@qhdrl12/mcp-server-gemini-image-generator/badge" alt="Gemini Image Generator Server MCP server" />
+</a>
+
 # Gemini Image Generator MCP Server
 
 Generate high-quality images from text prompts using Google's Gemini model through the MCP protocol.


### PR DESCRIPTION
This PR adds a badge for the [Gemini Image Generator MCP Server](https://glama.ai/mcp/servers/@qhdrl12/mcp-server-gemini-image-generator) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@qhdrl12/mcp-server-gemini-image-generator">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@qhdrl12/mcp-server-gemini-image-generator/badge" alt="Gemini Image Generator Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.